### PR TITLE
Use the onload event to get correct size

### DIFF
--- a/house/static/house/dressing_room.js
+++ b/house/static/house/dressing_room.js
@@ -25,6 +25,9 @@ $(document).ready(function(){
       selectedAccessoryPath = accessorySelectBox.options[accessorySelectBox.selectedIndex].value;
       if (accessoryCreated == 0) {
         accessory.src = selectedAccessoryPath;
+        $(accessory).load(function() {
+          console.log("Image finished loading:", accessory.clientHeight, accessory.clientWidth);
+        });
         $( "#accessory-box" ).append(accessory);
         console.log("loop accessory height = " + accessory.clientHeight);
         console.log("loop accessory width = " + accessory.clientWidth);


### PR DESCRIPTION
When an image is added to the DOM, its initial size appears to be either 0x0 (in Chrome) or some random size (in Firefox). Listen to the onload event in order to get its real size once it has finished loading.
